### PR TITLE
feat: home screen base implemented

### DIFF
--- a/assets/arrowDown.svg
+++ b/assets/arrowDown.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="5" viewBox="0 0 14 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.645 0.0108643L7 2.68253L12.355 0.0108643L14 0.833364L7 4.33336L0 0.833364L1.645 0.0108643Z" fill="#FFE6A7"/>
+</svg>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:EasyGroceries/config.dart';
 import 'package:EasyGroceries/screens/redirections.dart';
+import 'package:EasyGroceries/style/colors.dart';
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
 void main() {
@@ -16,9 +18,26 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
+      defaultTransition: Transition.fade,
       debugShowCheckedModeBanner: false,
-      home: Redirections(),
-      getPages: [],
+      theme: ThemeData(
+        colorScheme: ColorScheme.light(
+          primary: mainColor,
+        ),
+      ),
+      getPages: [
+        GetPage(
+          name: "/",
+          page: () => AnnotatedRegion<SystemUiOverlayStyle>(
+              value: SystemUiOverlayStyle(
+                statusBarColor: Colors.transparent,
+                systemNavigationBarColor: Colors.transparent,
+                statusBarIconBrightness: Brightness.dark,
+                systemNavigationBarIconBrightness: Brightness.dark,
+              ),
+              child: Redirections()),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/home/CAcard.dart
+++ b/lib/screens/home/CAcard.dart
@@ -1,0 +1,68 @@
+import 'package:EasyGroceries/style/textStyle.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class CAcard extends StatelessWidget {
+  final Map<String, dynamic> slide;
+
+  CAcard({@required this.slide});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {},
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Container(
+          decoration: BoxDecoration(
+              color: Colors.black, borderRadius: BorderRadius.circular(10.0)),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AutoSizeText(
+                      slide["title"],
+                      style: textStyleH1Accent,
+                      maxLines: 1,
+                    ),
+                    AutoSizeText(
+                      slide["desc"],
+                      style: textStyleH2White,
+                      maxLines: 1,
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(child: Container()),
+              Center(
+                  child: Container(
+                height: 40,
+                width: 100,
+                decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.5),
+                    borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(10.0),
+                        topRight: Radius.circular(10.0))),
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      AutoSizeText(slide["clickHint"],
+                          style: textStyleH2Accent, maxLines: 1),
+                    ],
+                  ),
+                ),
+              ))
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/consts.dart
+++ b/lib/screens/home/consts.dart
@@ -1,0 +1,20 @@
+final caSlides = [
+  {
+    "title": "RECIEPE OF THE WEEK",
+    "desc": "Boeuf Bourguignon",
+    "image": "",
+    "clickHint": "Let's cook it !"
+  },
+  {
+    "title": "EASYGROCERIES MAP",
+    "desc": "Find all the closest grocery stores from you !",
+    "image": "",
+    "clickHint": "Let's go !"
+  },
+  {
+    "title": "SEASONAL FRUITS",
+    "desc": "The must-have fruits for this season !",
+    "image": "",
+    "clickHint": "Let me see !"
+  },
+];

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -1,12 +1,93 @@
+import 'package:EasyGroceries/screens/consts.dart';
+import 'package:EasyGroceries/screens/home/CAcard.dart';
+import 'package:EasyGroceries/screens/home/consts.dart';
+import 'package:EasyGroceries/style/colors.dart';
+import 'package:EasyGroceries/style/swiperPaginationStyle.dart';
+import 'package:EasyGroceries/style/textStyle.dart';
+import 'package:EasyGroceries/utils/profilePicture.dart';
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_swiper/flutter_swiper.dart';
 
 class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Center(
-      child: Text("HomeScreen"),
+        body: Column(
+      children: [
+        Flexible(
+          flex: 4,
+          fit: FlexFit.tight,
+          child: _getProfileSection(),
+        ),
+        Flexible(
+          flex: 4,
+          fit: FlexFit.tight,
+          child: _getCaSection(),
+        ),
+        Flexible(
+          flex: 5,
+          fit: FlexFit.tight,
+          child: _getShoppingListSection(),
+        )
+      ],
     ));
+  }
+
+  _getProfileSection() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            flex: 10,
+            child: ProfilePicture(
+              height: 100,
+              width: 100,
+            ),
+          ),
+          Flexible(flex: 1, child: Container()),
+          Flexible(
+              flex: 1,
+              child: AutoSizeText("Hey there ! ✌️", style: textStyleH1))
+        ],
+      ),
+    );
+  }
+
+  _getCaSection() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Swiper(
+        autoplay: true,
+        autoplayDelay: 10000,
+        duration: 500,
+        itemCount: caSlides.length,
+        outer: true,
+        loop: true,
+        pagination: getCustomSwiperPagination(),
+        itemBuilder: (BuildContext context, int index) {
+          return CAcard(
+            slide: caSlides[index],
+          );
+        },
+      ),
+    );
+  }
+
+  _getShoppingListSection() {
+    return Container(
+      width: appWidth,
+      color: mainColor,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: AutoSizeText(
+          "MY NEXT GROCERY SHOPPING LIST",
+          style: textStyleH3Bold,
+          maxLines: 1,
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/redirections.dart
+++ b/lib/screens/redirections.dart
@@ -18,6 +18,12 @@ class Redirections extends StatelessWidget {
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]);
+    SystemUiOverlayStyle(
+      statusBarColor: Colors.white,
+      systemNavigationBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.dark,
+      systemNavigationBarIconBrightness: Brightness.dark,
+    );
   }
 
   @override

--- a/lib/style/colors.dart
+++ b/lib/style/colors.dart
@@ -2,3 +2,5 @@ import 'package:flutter/cupertino.dart';
 
 const Color mainColor = const Color(0xFFA6D388);
 const Color secondaryColor = const Color(0xFFCDEABB);
+const Color accentColor = const Color(0xFFFFE6A7);
+const Color grey = const Color(0xFFC4C4C4);

--- a/lib/style/swiperPaginationStyle.dart
+++ b/lib/style/swiperPaginationStyle.dart
@@ -1,0 +1,21 @@
+import 'package:EasyGroceries/style/colors.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_swiper/flutter_swiper.dart';
+
+SwiperPagination getCustomSwiperPagination() {
+  return SwiperPagination(builder: SwiperCustomPagination(
+      builder: (BuildContext context, SwiperPluginConfig config) {
+    return new ConstrainedBox(
+      child: new Align(
+        alignment: Alignment.center,
+        child: new DotSwiperPaginationBuilder(
+                color: grey,
+                activeColor: accentColor,
+                size: 10.0,
+                activeSize: 10.0)
+            .build(context, config),
+      ),
+      constraints: new BoxConstraints.expand(height: 20.0),
+    );
+  }));
+}

--- a/lib/style/textStyle.dart
+++ b/lib/style/textStyle.dart
@@ -1,15 +1,36 @@
 import 'package:EasyGroceries/style/colors.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 const TextStyle textStyleH1 = TextStyle(
   fontWeight: FontWeight.w300,
   fontSize: 22.0,
 );
 
+const TextStyle textStyleH1Accent =
+    TextStyle(fontWeight: FontWeight.w300, fontSize: 22.0, color: accentColor);
+
+// H2
+
 const TextStyle textStyleH2 = TextStyle(
   fontWeight: FontWeight.w300,
   fontSize: 16.0,
 );
+
+const TextStyle textStyleH2Accent =
+    TextStyle(fontWeight: FontWeight.w300, fontSize: 16.0, color: accentColor);
+
+const TextStyle textStyleH2White =
+    TextStyle(fontWeight: FontWeight.w300, fontSize: 16.0, color: Colors.white);
+
+// H3
+
+const TextStyle textStyleH3Bold = TextStyle(
+  fontWeight: FontWeight.w500,
+  fontSize: 14.0,
+);
+
+// special case
 
 const TextStyle textStyleNext =
     TextStyle(fontWeight: FontWeight.normal, fontSize: 16.0, color: mainColor);

--- a/lib/utils/profilePicture.dart
+++ b/lib/utils/profilePicture.dart
@@ -1,0 +1,27 @@
+import 'package:EasyGroceries/style/colors.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class ProfilePicture extends StatelessWidget {
+  final double height;
+  final double width;
+  final String pictureUrl;
+
+  ProfilePicture(
+      {@required this.height, @required this.width, this.pictureUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        height: height,
+        width: width,
+        decoration: BoxDecoration(color: mainColor, shape: BoxShape.circle),
+        child: pictureUrl == null
+            ? Icon(
+                Icons.person,
+                size: height * 0.70,
+                color: Colors.white,
+              )
+            : Container());
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,6 +125,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.8.1"
+  flutter_page_indicator:
+    dependency: transitive
+    description:
+      name: flutter_page_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.3"
   flutter_spinkit:
     dependency: "direct main"
     description:
@@ -132,6 +139,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.2+1"
+  flutter_swiper:
+    dependency: "direct main"
+    description:
+      name: flutter_swiper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -399,6 +413,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.19-nullsafety.2"
+  transformer_page_view:
+    dependency: transitive
+    description:
+      name: transformer_page_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.6"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   localstorage: ^3.0.0
   flutter_spinkit: "^4.1.2"
   flutter_launcher_icons: "^0.8.0"
+  flutter_swiper: ^1.1.6
 
 flutter_icons:
   android: "launcher_icon"

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:EasyGroceries/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:easyGroceries/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
This PR contains the first implementation of the home screen :

- [+] Profile section.
- [+] Contextual area.
- [+] Shopping list section.
- [+] Top bar (android) is now transparent.
- [+] Package `flutter_slider`.

I wanted to implement the `flutter_svg` package but it seems that something doesn't work properly, I left a ticket there -> https://github.com/dnfield/flutter_svg/issues/456

![Screenshot_20201124_175537_com example easyGroceries](https://user-images.githubusercontent.com/54772403/100126522-56166f80-2e7e-11eb-94af-8d54a5927a83.jpg)
